### PR TITLE
Update for changes to Expo imports in SDK 33

### DIFF
--- a/src/CacheManager.js
+++ b/src/CacheManager.js
@@ -1,6 +1,6 @@
 // @flow
 import * as _ from "lodash";
-import {FileSystem} from "expo";
+import * as FileSystem from 'expo-file-system';
 import SHA1 from "crypto-js/sha1";
 
 export type DownloadOptions = {

--- a/src/Image.js
+++ b/src/Image.js
@@ -2,7 +2,7 @@
 import * as _ from "lodash";
 import * as React from "react";
 import {Image as RNImage, Animated, StyleSheet, View, Platform} from "react-native";
-import {BlurView} from "expo";
+import { BlurView } from 'expo-blur';
 import { type ____ImageStyleProp_Internal as ImageStyle } from "react-native/Libraries/StyleSheet/StyleSheetTypes";
 import type {ImageSourcePropType} from "react-native/Libraries/Image/ImageSourcePropType";
 


### PR DESCRIPTION
At SDK 33 many functions were moved to their own modules
https://docs.expo.io/versions/v33.0.0/sdk/filesystem/
https://docs.expo.io/versions/v33.0.0/sdk/blur-view/